### PR TITLE
Fixing parallel power spectrum crashes

### DIFF
--- a/soapfast/get_power_spectrum.py
+++ b/soapfast/get_power_spectrum.py
@@ -28,6 +28,10 @@ def get_power_spectrum(lam,frames,nmax=8,lmax=6,rc=4.0,sg=0.3,ncut=-1,cw=1.0,per
     
     # Get coordinates and names
     npoints   = len(frames)
+    # If we have called this function without any frames, return softly
+    if (npoints==0):
+        print("No frames passed to get_power_spectrum")
+        return 0
     all_names = np.array([frames[i].get_chemical_symbols() for i in range(npoints)])
     natmax    = len(max(all_names, key=len))
     coords    = [frames[i].get_positions() for i in range(npoints)]

--- a/soapfast/scripts/stack_power_spectra.py
+++ b/soapfast/scripts/stack_power_spectra.py
@@ -8,8 +8,14 @@ outfile = os.environ.get("outfile")
 nrun = int(os.environ.get("numrun"))
 
 # Read in power spectrum and number of atoms
-all_ps=[np.load("PS_output_" + str(i+1) + ".npy") for i in range(nrun)]
-all_natom=[np.load("PS_output_" + str(i+1) + "_natoms.npy") for i in range(nrun)]
+all_ps = []
+all_natom = []
+for i in range(nrun):
+    if (os.path.exists("PS_output_" + str(i+1) + ".npy")):
+        all_ps.append(np.load("PS_output_" + str(i+1) + ".npy"))
+        all_natom.append(np.load("PS_output_" + str(i+1) + "_natoms.npy"))
+
+nrun = len(all_ps)
 
 # Put power spectra together
 npoints = sum([np.shape(all_ps[i])[0] for i in range(nrun)])


### PR DESCRIPTION
I've modified the code so that there should no longer be hard crashes if any instances of `sagpr_get_PS` are called with no frames given to it. This isn't necessarily the best fix, as there's no guarantee that every core has been given the optimum number of frames; but it should stop the hard exits we had before. Fixes #8 

@max-veit please let me know if this fixes the problem you had