### PR TITLE
Added vol_frac option to get_power_spectrum

### DIFF
--- a/soapfast/get_power_spectrum.py
+++ b/soapfast/get_power_spectrum.py
@@ -13,7 +13,7 @@ import random
 
 ###############################################################################################################################
 
-def get_power_spectrum(lam,frames,nmax=8,lmax=6,rc=4.0,sg=0.3,ncut=-1,cw=1.0,periodic=False,outfile='',subset=['NO',None],initial=-1,sparsefile='',sparse_options=[''],cen=[],spec=[],atomic=[False,None],all_radial=[1.0,0.0,0.0],useall=False,xyz_slice=[],verbose=True,get_imag=False,norm=True,electro=False,sigewald=1.0,single_radial=False,radsize=50,lebsize=146,average=False):
+def get_power_spectrum(lam,frames,nmax=8,lmax=6,rc=4.0,sg=0.3,ncut=-1,cw=1.0,periodic=False,outfile='',subset=['NO',None],initial=-1,sparsefile='',sparse_options=[''],cen=[],spec=[],atomic=[False,None],all_radial=[1.0,0.0,0.0],useall=False,xyz_slice=[],verbose=True,get_imag=False,norm=True,electro=False,sigewald=1.0,single_radial=False,radsize=50,lebsize=146,average=False,vol_frac=1.0):
 
     # If we want a slice of the coordinates, do this BEFORE anything else.
     if (len(xyz_slice)!=0):
@@ -64,7 +64,7 @@ def get_power_spectrum(lam,frames,nmax=8,lmax=6,rc=4.0,sg=0.3,ncut=-1,cw=1.0,per
         # Maximum number of atoms in one cluster (Safest option)
         nnmax = np.max([len(d) for d in frames]) 
     else: 
-        max_density = max([len(d)*1.0/d.get_volume() for d in frames])
+        max_density = max([len(d)*1.0/(vol_frac*d.get_volume()) for d in frames])
         nnmax = int(np.floor((4.0/3. *np.pi* rc**3) * max_density * 2))
         if electro==True:
             nnmax = 100
@@ -308,12 +308,12 @@ def main():
     pname = os.path.dirname(os.path.realpath(__file__))
     if os.path.isfile(pname + "/utils/LODE/gvectors.so"):
         args = parse.add_command_line_arguments_PS("Calculate power spectrum")
-        [nmax,lmax,rcut,sig,cen,spec,cweight,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,initial,atomic,all_radial,useall,xyz_slice,get_imag,nonorm,electro,sigewald,single_radial,radsize,lebsize,average] = parse.set_variable_values_PS(args)
-        get_power_spectrum(lam,frames,nmax=nmax,lmax=lmax,rc=rcut,sg=sig,ncut=ncut,periodic=periodic,outfile=outfile,cw=cweight,subset=subset,initial=initial,sparsefile=sparsefile,sparse_options=sparse_options,cen=cen,spec=spec,atomic=atomic,all_radial=all_radial,useall=useall,xyz_slice=xyz_slice,get_imag=get_imag,norm=(not nonorm),electro=electro,sigewald=sigewald,single_radial=single_radial,radsize=radsize,lebsize=lebsize,average=average)
+        [nmax,lmax,rcut,sig,cen,spec,cweight,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,initial,atomic,all_radial,useall,xyz_slice,get_imag,nonorm,electro,sigewald,single_radial,radsize,lebsize,average,vol_frac] = parse.set_variable_values_PS(args)
+        get_power_spectrum(lam,frames,nmax=nmax,lmax=lmax,rc=rcut,sg=sig,ncut=ncut,periodic=periodic,outfile=outfile,cw=cweight,subset=subset,initial=initial,sparsefile=sparsefile,sparse_options=sparse_options,cen=cen,spec=spec,atomic=atomic,all_radial=all_radial,useall=useall,xyz_slice=xyz_slice,get_imag=get_imag,norm=(not nonorm),electro=electro,sigewald=sigewald,single_radial=single_radial,radsize=radsize,lebsize=lebsize,average=average,vol_frac=vol_frac)
     else:
         args = parse.add_command_line_arguments_PS("Calculate power spectrum")
-        [nmax,lmax,rcut,sig,cen,spec,cweight,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,initial,atomic,all_radial,useall,xyz_slice,get_imag,nonorm] = parse.set_variable_values_PS(args)
-        get_power_spectrum(lam,frames,nmax=nmax,lmax=lmax,rc=rcut,sg=sig,ncut=ncut,periodic=periodic,outfile=outfile,cw=cweight,subset=subset,initial=initial,sparsefile=sparsefile,sparse_options=sparse_options,cen=cen,spec=spec,atomic=atomic,all_radial=all_radial,useall=useall,xyz_slice=xyz_slice,get_imag=get_imag,norm=(not nonorm))
+        [nmax,lmax,rcut,sig,cen,spec,cweight,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,initial,atomic,all_radial,useall,xyz_slice,get_imag,nonorm,vol_frac] = parse.set_variable_values_PS(args)
+        get_power_spectrum(lam,frames,nmax=nmax,lmax=lmax,rc=rcut,sg=sig,ncut=ncut,periodic=periodic,outfile=outfile,cw=cweight,subset=subset,initial=initial,sparsefile=sparsefile,sparse_options=sparse_options,cen=cen,spec=spec,atomic=atomic,all_radial=all_radial,useall=useall,xyz_slice=xyz_slice,get_imag=get_imag,norm=(not nonorm),vol_frac=vol_frac)
 
 if __name__=="__main__":
     from utils import regression_utils

--- a/soapfast/utils/LODE/parsing.py
+++ b/soapfast/utils/LODE/parsing.py
@@ -42,6 +42,7 @@ def add_command_line_arguments_PS(parsetext):
     parser.add_argument("-rad", "--radsize", type=int,  default=50,                                 help="Dimension of the Gauss-Legendre grid needed for the numerical radial integration of the direct-space potential")
     parser.add_argument("-leb", "--lebsize", type=int,  default=146,                                 help="Dimension of the Lebedev grid needed for the numerical angular integration of the direct-space potential. Choose among [6, 14, 26, 38, 50, 74, 86, 110, 146, 170, 194, 230, 266, 302, 350, 434, 590, 770, 974, 1202, 1454, 1730, 2030 (army grade), 2354, 2702, 3074, 3470, 3890, 4334, 4802, 5294, 5810]")
     parser.add_argument("-ave",  "--average",                  action='store_true',                      help="Structural averaged features?")
+    parser.add_argument("-vf", "--vol_frac",       type=float, default=1.0,                              help="Specify the occupied fraction of the cell")
 
     args = parser.parse_args()
     return args
@@ -132,6 +133,6 @@ def set_variable_values_PS(args):
             sys.exit(0)
         xyz_slice = [args.slice[0],args.slice[1]]
 
-    return [nmax,lmax,rc,sg,cen,spec,cw,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,args.initial,atomic,all_radial,not args.uselist,xyz_slice,args.imag,args.nonorm,ele,sew,srad,rad,leb,ave]
+    return [nmax,lmax,rc,sg,cen,spec,cw,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,args.initial,atomic,all_radial,not args.uselist,xyz_slice,args.imag,args.nonorm,ele,sew,srad,rad,leb,ave,args.vol_frac]
 
 #########################################################################

--- a/soapfast/utils/initsoap.pyx
+++ b/soapfast/utils/initsoap.pyx
@@ -126,6 +126,7 @@ cdef void _initsoapperiodic(long nspecies,
     cdef Py_ssize_t icentype,centype,icen,cen,ispe,ineigh,neigh,ia,ib,ic,lval,mval,im,n 
     cdef double rx,ry,rz,rcx,rcy,rcz,sx,sy,sz,ph,th,r2,rdist,rrx,rry,rrz
 
+    nnmax = length.shape[2]
     iat = 0
     ncentype = len(centers)
     # loop over species to center on
@@ -165,6 +166,9 @@ cdef void _initsoapperiodic(long nspecies,
                                 r2 = rrx**2 + rry**2 + rrz**2
                                 # within cutoff ?
                                 if r2 <= rcut**2:
+                                    if n > nnmax:
+                                        print "The number of nearest neighbours exceeds the estimated maximum. Please reduce the value of the flag vol_frac when calling get_power_spectrum."
+                                        sys.exit()
                                     # central atom ?
                                     if neigh == cen and ia==0 and ib==0 and ic==0:
                                         length[iat,ispe,n]  = 0.0

--- a/soapfast/utils/parsing.py
+++ b/soapfast/utils/parsing.py
@@ -177,6 +177,7 @@ def add_command_line_arguments_PS(parsetext):
     parser.add_argument("-sl", "--slice",         type=int,   default=-1,    nargs='+',                 help="Choose a slice of the input frames to calculate the power spectrum")
     parser.add_argument("-im", "--imag",                      action='store_true',                      help="Get imaginary power spectrum for building SO(3) kernel")
     parser.add_argument("-nn", "--nonorm",                    action='store_true',                      help="Do not normalize power spectrum")
+    parser.add_argument("-vf", "--vol_frac",       type=float, default=1.0,                              help="Specify the occupied fraction of the cell")
 
     args = parser.parse_args()
     return args
@@ -261,7 +262,7 @@ def set_variable_values_PS(args):
             sys.exit(0)
         xyz_slice = [args.slice[0],args.slice[1]]
 
-    return [nmax,lmax,rc,sg,cen,spec,cw,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,args.initial,atomic,all_radial,not args.uselist,xyz_slice,args.imag,args.nonorm]
+    return [nmax,lmax,rc,sg,cen,spec,cw,lam,periodic,ncut,sparsefile,frames,subset,sparse_options,outfile,args.initial,atomic,all_radial,not args.uselist,xyz_slice,args.imag,args.nonorm,args.vol_frac]
 
 #########################################################################
 


### PR DESCRIPTION
Added vol_frac option to get_power_spectrum, to handle cells which contain vacuum regions. Specifying a fraction less than 1.0 effectively increases the estimate for the maximum possible number of nearest neighbours.